### PR TITLE
Add cancelLastTask operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ env_logger = "0.9.0"
 # MultiRotor examples
 [[example]]
 crate-type = ["bin"]
+name = "cancel_culture"
+path = "examples/multirotor/cancel_culture.rs"
+
+[[example]]
+crate-type = ["bin"]
 name = "connect_drone"
 path = "examples/multirotor/connect.rs"
 

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -67,7 +67,7 @@ async fn connect_drone() -> NetworkResult<()> {
     // disarm drone
     log::info!("disarm drone");
     let res = client.arm_disarm(false).await?;
-    log::info!("Response: {:?}", res);
+    log::info!("Response: {res:?}");
 
     // reset drone
     task::sleep(Duration::from_secs(1)).await;

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -73,7 +73,7 @@ async fn connect_drone() -> NetworkResult<()> {
     task::sleep(Duration::from_secs(1)).await;
     log::info!("reset drone");
     let res = client.reset().await?;
-    log::info!("Response: {:?}", res);
+    log::info!("Response: {res:?}");
 
     log::info!("Done!");
     Ok(())

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -62,7 +62,7 @@ async fn connect_drone() -> NetworkResult<()> {
     // land drone
     log::info!("land drone");
     let res = client.land_async(20.0).await?;
-    log::info!("Response: {:?}", res);
+    log::info!("Response: {res:?}");
 
     // disarm drone
     log::info!("disarm drone");

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -36,7 +36,7 @@ async fn connect_drone() -> NetworkResult<()> {
     // arm drone
     log::info!("arm drone");
     let res = client.arm_disarm(true).await?;
-    log::info!("Response: {:?}", res);
+    log::info!("Response: {res:?}");
 
     // Start the canceller at the background
     task::spawn(cancel_ongoing_async());

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+use airsim_client::{DrivetrainType, MultiRotorClient, NetworkResult, Position3, YawMode};
+use async_std::task;
+
+use futures::future::FutureExt;
+
+async fn cancel_ongoing_async() -> NetworkResult<()> {
+    let address = "127.0.0.1:41451";
+    let vehicle_name = "";
+
+    // connect
+    log::info!("connect for cancelling");
+    let client = MultiRotorClient::connect(address, vehicle_name).await?;
+    task::sleep(Duration::from_secs(5)).await;
+
+    let res = client.cancel_last_task().await?;
+    log::info!("cancelled successfully: {res:?}");
+    Ok(())
+}
+async fn connect_drone() -> NetworkResult<()> {
+    let address = "127.0.0.1:41451";
+    let vehicle_name = "";
+
+    log::info!("Start!");
+
+    // connect
+    log::info!("connect");
+    let client = MultiRotorClient::connect(address, vehicle_name).await?;
+
+    // confirm connect
+    log::info!("confirm connection");
+    let res = client.confirm_connection().await?;
+    log::info!("Response: {:?}", res);
+
+    // arm drone
+    log::info!("arm drone");
+    let res = client.arm_disarm(true).await?;
+    log::info!("Response: {:?}", res);
+
+    // Start the canceller at the background
+    task::spawn(cancel_ongoing_async());
+
+    // take off
+    log::info!("take off drone");
+    let _t1 = client.take_off_async(20.0).fuse().await?;
+    let _t2 = task::sleep(Duration::from_secs(10)).fuse();
+
+    log::info!("move to position");
+    client
+        .move_to_position_async(
+            Position3::new(-10.0, 10.0, -100.0),
+            3.0,
+            1000.0,
+            DrivetrainType::ForwardOnly,
+            YawMode::new(false, 90.0),
+            None,
+            None,
+        )
+        .await?;
+
+    // land drone
+    log::info!("land drone");
+    let res = client.land_async(20.0).await?;
+    log::info!("Response: {:?}", res);
+
+    // disarm drone
+    log::info!("disarm drone");
+    let res = client.arm_disarm(false).await?;
+    log::info!("Response: {:?}", res);
+
+    // reset drone
+    task::sleep(Duration::from_secs(1)).await;
+    log::info!("reset drone");
+    let res = client.reset().await?;
+    log::info!("Response: {:?}", res);
+
+    log::info!("Done!");
+    Ok(())
+}
+
+fn main() -> NetworkResult<()> {
+    env_logger::init();
+    task::block_on(connect_drone())
+}

--- a/examples/multirotor/cancel_culture.rs
+++ b/examples/multirotor/cancel_culture.rs
@@ -31,7 +31,7 @@ async fn connect_drone() -> NetworkResult<()> {
     // confirm connect
     log::info!("confirm connection");
     let res = client.confirm_connection().await?;
-    log::info!("Response: {:?}", res);
+    log::info!("Response: {res:?}");
 
     // arm drone
     log::info!("arm drone");

--- a/src/clients/airsim_client.rs
+++ b/src/clients/airsim_client.rs
@@ -411,6 +411,18 @@ impl AirsimClient {
         .map(|response| response.result.is_ok() && response.result.unwrap().as_bool() == Some(true))
     }
 
+    /// Cancel previous Async task
+    ///
+    /// args:
+    ///      vehicle_name (Option<&str>): Name of the vehicle to send this command to
+    pub(crate) async fn cancel_last_task(&self, vehicle_name: Option<&str>) -> NetworkResult<bool> {
+        let vehicle_name: Utf8String = vehicle_name.unwrap_or("").into();
+
+        self.unary_rpc("cancelLastTask".into(), Some(vec![Value::String(vehicle_name)]))
+            .await
+            .map(|response| response.result.is_ok())
+    }
+
     /// Returns true if API control is established.
     ///
     /// If false (which is default) then API calls would be ignored. After a successful call

--- a/src/clients/car_client.rs
+++ b/src/clients/car_client.rs
@@ -66,6 +66,12 @@ impl CarClient {
             .await
     }
 
+    /// Cancel previous Async task
+    #[inline(always)]
+    pub async fn cancel_last_task(&self) -> NetworkResult<bool> {
+        self.airsim_client.cancel_last_task(Some(self.vehicle_name)).await
+    }
+
     /// Returns true if API control is established.
     ///
     /// If false (which is default) then API calls would be ignored. After a successful call

--- a/src/clients/multi_rotor_client.rs
+++ b/src/clients/multi_rotor_client.rs
@@ -77,6 +77,12 @@ impl MultiRotorClient {
             .await
     }
 
+    /// Cancel previous Async task
+    #[inline(always)]
+    pub async fn cancel_last_task(&self) -> NetworkResult<bool> {
+        self.airsim_client.cancel_last_task(Some(self.vehicle_name)).await
+    }
+
     /// Returns true if API control is established.
     ///
     /// If false (which is default) then API calls would be ignored. After a successful call


### PR DESCRIPTION
cancelLastTask operation is necessary where user needs to cut the current operation in the middle for variety of reasons. cancelLastTask should be executed from another task though if current task is executing an async task and awaiting for it. An example is also added. task will be executing